### PR TITLE
Handle Selenium "options" deprecation

### DIFF
--- a/spec/support/webdrivers.rb
+++ b/spec/support/webdrivers.rb
@@ -12,7 +12,7 @@ Capybara.register_driver :headless_chrome do |app|
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    options: options,
+    capabilities: [options],
   )
 end
 


### PR DESCRIPTION
Working on getting tests running automatically on our branch.

Silences this warning while running "bundle exec rspec":

    WARN Selenium [DEPRECATION] [:browser_options] :options as a parameter for
    driver initialization is deprecated. Use :capabilities with an Array of
    value capabilities/options if necessary instead.

Also opened a PR upstream: https://github.com/thoughtbot/administrate/pull/2118