### PR TITLE
Remove dependabot from our branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-
-updates:
-- package-ecosystem: bundler
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10


### PR DESCRIPTION
Since we already do this on our target app (Web) and since we're trying to track upstream for the most part it seems like we should probably disable this to avoid the noise.