### PR TITLE
Add "webrick" to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
+    webrick (1.7.0)
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -348,6 +349,7 @@ DEPENDENCIES
   uglifier
   unicorn
   webmock
+  webrick
   xpath (= 3.2.0)
   yard
 

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -39,6 +39,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/gemfiles/rails51.gemfile
+++ b/gemfiles/rails51.gemfile
@@ -39,6 +39,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/gemfiles/rails52.gemfile
+++ b/gemfiles/rails52.gemfile
@@ -39,6 +39,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/gemfiles/rails60.gemfile
+++ b/gemfiles/rails60.gemfile
@@ -36,6 +36,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 

--- a/gemfiles/rails61.gemfile
+++ b/gemfiles/rails61.gemfile
@@ -36,6 +36,7 @@ group :test do
   gem "shoulda-matchers"
   gem "timecop"
   gem "webmock"
+  gem "webrick"
   gem "xpath", "3.2.0"
 end
 


### PR DESCRIPTION
Also opened upstream: https://github.com/thoughtbot/administrate/pull/2120

As of Ruby 3.0 webrick is no longer part of the Ruby standard library:
https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/