### PR TITLE
Set _pundit_policy_scoped instance variable

### DIFF
--- a/app/controllers/concerns/administrate/punditize.rb
+++ b/app/controllers/concerns/administrate/punditize.rb
@@ -24,6 +24,7 @@ module Administrate
       # to be overridden by 'resolve_admin' for a different index scope in Admin
       # controllers.
       def policy_scope_admin(scope)
+        @_pundit_policy_scoped = true
         ps = Pundit::PolicyFinder.new(scope).scope!.new(pundit_user, scope)
         if ps.respond_to? :resolve_admin
           ps.resolve_admin


### PR DESCRIPTION
Pundit exposes the [policy_scope](https://github.com/varvet/pundit#scopes) method which [internally](https://github.com/varvet/pundit/blob/6513071aa790f061dec72e676b99996fa007c9ff/lib/pundit/authorization.rb#L92-L95) sets the `@_pundit_policy_scoped` instance variable.

When using the `verify_policy_scoped` callback for [ensuring scopes are used](https://github.com/varvet/pundit#ensuring-policies-and-scopes-are-used), pundit checks whether this instance variable has been set in the context of a request. If it hasn't it raises the `Pundit::PolicyScopingNotPerformedError` error. Since administrate defines its own `policy_scope_admin` method, we also need to set this instance variable there to avoid the error being raised.

I also opened a [PR](https://github.com/thoughtbot/administrate/pull/2347) to the upstream repository with this change.