### PR TITLE
Update `Administrate::Search` to use dynamic attribute types

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -122,7 +122,14 @@ module Administrate
     end
 
     def attribute_types
-      @dashboard_class::ATTRIBUTE_TYPES
+      # RINSED: Allow using dynamically-added attribute_types in our BaseDashboard.
+      # TODO: Upstream this
+      if defined?(@dashboard_class.new.attribute_types)
+        @dashboard_class.new.attribute_types
+      else
+        @dashboard_class::ATTRIBUTE_TYPES
+      end
+      # END RINSED
     end
 
     def query_table_name(attr)

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -35,7 +35,9 @@ describe Administrate::Search do
 
         class UserDashboard
           ATTRIBUTE_TYPES = {
-            id: Administrate::Field::Number.with_options(searchable: true),
+            # RINSED
+            # id: Administrate::Field::Number.with_options(searchable: true),
+            # END RINSED
             name: Administrate::Field::String,
             email: Administrate::Field::Email,
             phone: Administrate::Field::Number,
@@ -44,6 +46,12 @@ describe Administrate::Search do
           COLLECTION_FILTERS = {
             vip: ->(resources) { resources.where(kind: :vip) },
           }.freeze
+
+          # RINSED
+          def attribute_types
+            @attribute_types ||= { id: Administrate::Field::Number.with_options(searchable: true) }.merge(ATTRIBUTE_TYPES)
+          end
+          # END RINSED
         end
 
         class FooDashboard


### PR DESCRIPTION
Our BaseDashboard adds some dynamic attribute types via the `attribute_types` method. This allows the Search class to use them, so that they are searchable (in particular at the moment: `eid` fields).

TODO: Upstream this.

https://app.shortcut.com/rinsed/story/13241