### PR TITLE
Allow customizing columns in HasMany dashboards

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -25,7 +25,7 @@ to display a collection of resources in an HTML table.
         <th class="cell-label
         cell-label--<%= attr_type.html_class %>
         cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
-        cell-label--<%= "#{resource_name}_#{attr_name}" %>"
+        cell-label--<%= "#{collection_presenter.resource_name}_#{attr_name}" %>"
         scope="col"
         role="columnheader"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">

--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -24,7 +24,8 @@ to display a collection of resources in an HTML table.
       <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
         <th class="cell-label
         cell-label--<%= attr_type.html_class %>
-        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>
+        cell-label--<%= "#{resource_name}_#{attr_name}" %>"
         scope="col"
         role="columnheader"
         aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">

--- a/lib/administrate/field/has_many.rb
+++ b/lib/administrate/field/has_many.rb
@@ -22,7 +22,11 @@ module Administrate
       end
 
       def associated_collection(order = self.order)
-        Administrate::Page::Collection.new(associated_dashboard, order: order)
+        Administrate::Page::Collection.new(
+          associated_dashboard,
+          order: order,
+          collection_attributes: options[:collection_attributes],
+        )
       end
 
       def attribute_key

--- a/lib/administrate/page/collection.rb
+++ b/lib/administrate/page/collection.rb
@@ -4,6 +4,7 @@ module Administrate
   module Page
     class Collection < Page::Base
       def attribute_names
+        options.fetch(:collection_attributes, nil) ||
         dashboard.collection_attributes
       end
 

--- a/spec/example_app/app/dashboards/order_dashboard.rb
+++ b/spec/example_app/app/dashboards/order_dashboard.rb
@@ -11,7 +11,9 @@ class OrderDashboard < Administrate::BaseDashboard
     address_state: Field::String,
     address_zip: Field::String,
     customer: Field::BelongsTo,
-    line_items: Field::HasMany,
+    line_items: Field::HasMany.with_options(
+      collection_attributes: %i[product quantity unit_price total_price],
+    ),
     total_price: Field::Number.with_options(prefix: "$", decimals: 2),
     shipped_at: Field::DateTime,
     payments: Field::HasMany,

--- a/spec/features/index_page_spec.rb
+++ b/spec/features/index_page_spec.rb
@@ -13,6 +13,12 @@ describe "customer index page" do
     expect(page).to have_content(customer.email)
   end
 
+  it "adds resource/attribute name to table headers" do
+    visit admin_customers_path
+
+    expect(page).to have_css("th.cell-label--customer_email")
+  end
+
   it "links to the customer show page", :js do
     customer = create(:customer)
 

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -99,6 +99,15 @@ RSpec.describe "customer show page" do
     end
   end
 
+  it "adds has_many resource/attribute name to table headers" do
+    customer = create(:customer)
+    create_list(:order, 2, customer: customer)
+
+    visit admin_customer_path(customer)
+
+    expect(page).to have_css("th.cell-label--order_total_price")
+  end
+
   it "sorts each of the customer's orders" do
     customer = create(:customer)
     orders = create_list(:order, 4, customer: customer)

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -257,6 +257,21 @@ RSpec.describe "customer show page" do
     end
   end
 
+  it "displays specified collection_attributes for the has_many association" do
+    line_item = create(:line_item)
+
+    visit admin_order_path(line_item.order)
+
+    within(table_for_attribute(:line_items)) do
+      columns = all("tr th").map do |e|
+        e[:class]&.split&.last&.split("--line_item_")&.last
+      end
+      expect(%w[product quantity unit_price total_price]).to(
+        eq(columns.first(4)),
+      )
+    end
+  end
+
   def ids_in_table
     all("tr td:first-child").map(&:text).map(&:to_i)
   end


### PR DESCRIPTION
Came out of discussion of @FabriceCastel's PR [here](https://github.com/rinsed-org/web/pull/14338).

Allows adding/removing/ordering the columns in a HasMany field, so that we can have a different view for a model's index page vs how the model shows up on other model's index pages.

I cherry-picked the following from [upstream administrate](https://github.com/thoughtbot/administrate):
* `Add resource/attribute name to table haders` (PR 2105) (used by following commit)
* `Fix table header classes of has_many field` (PR 2145) (used by following commit)
* `hasMany collection columns` (PR 2415) 👈 the functionality we want

