### PR TITLE
Create "rinsed-v1" branch (#7)

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -88,9 +88,10 @@ module Administrate
           attribute_type = attribute_types[attr]
 
           search_target = "#{table_name}.#{column_name}"
-          search_target = "LOWER(CAST(#{search_target} AS CHAR(256)))" if attribute_type.search_lower?
+          search_target = "CAST(#{search_target} AS CHAR(256))" unless attribute_type.search_exact?
+          search_target = "LOWER(#{search_target})" if attribute_type.search_lower?
 
-          if attribute_types[attr].search_exact?
+          if attribute_type.search_exact?
             "#{search_target} = ?"
           else
             "#{search_target} LIKE ?"


### PR DESCRIPTION
The `CAST(... AS CHAR(256))` prevents the query from leveraging the index:

Running `EXPLAIN` on the current (with `CAST`) query, then the version with the cast operation removed:

```
012 development johnnyclean > explain 'SELECT "emails"."id", "emails"."email_template_id", "emails"."created_at", "emails"."updated_at", "emails"."recipient_email", "emails"."customer_id", "emails"."variables", "emails"."is_test", "emails"."idempotency_key", "emails"."mandrill_message_id", "emails"."mandrill_message_status", "emails"."mandrill_message_reject_reason", "emails"."is_reminder", "emails"."clicked_at", "emails"."unsubscribed_at", "emails"."html", "emails"."eid", "emails"."sent_at", "emails"."sendgrid_x_message_id" FROM "emails" WHERE (LOWER(CAST("emails"."recipient_email" AS CHAR(256))) = \'micro.magic@woweee.io\') ORDER BY emails.created_at desc, "emails"."id" DESC LIMIT 20 OFFSET 0'
2025-01-13 22:47:23.409153 D ActiveRecord::Base --    (22.5ms)  EXPLAIN SELECT "emails"."id", "emails"."email_template_id", "emails"."created_at", "emails"."updated_at", "emails"."recipient_email", "emails"."customer_id", "emails"."variables", "emails"."is_test", "emails"."idempotency_key", "emails"."mandrill_message_id", "emails"."mandrill_message_status", "emails"."mandrill_message_reject_reason", "emails"."is_reminder", "emails"."clicked_at", "emails"."unsubscribed_at", "emails"."html", "emails"."eid", "emails"."sent_at", "emails"."sendgrid_x_message_id" FROM "emails" WHERE (LOWER(CAST("emails"."recipient_email" AS CHAR(256))) = 'micro.magic@woweee.io') ORDER BY emails.created_at desc, "emails"."id" DESC LIMIT 20 OFFSET 0
=>
[["Limit  (cost=14.01..14.02 rows=1 width=354)"],
 ["  ->  Sort  (cost=14.01..14.02 rows=1 width=354)"],
 ["        Sort Key: created_at DESC, id DESC"],
 ["        ->  Seq Scan on emails  (cost=0.00..14.00 rows=1 width=354)"],
 ["              Filter: (lower(((recipient_email)::character(256))::text) = 'micro.magic@woweee.io'::text)"]]
013 development johnnyclean > explain 'SELECT "emails"."id", "emails"."email_template_id", "emails"."created_at", "emails"."updated_at", "emails"."recipient_email", "emails"."customer_id", "emails"."variables", "emails"."is_test", "emails"."idempotency_key", "emails"."mandrill_message_id", "emails"."mandrill_message_status", "emails"."mandrill_message_reject_reason", "emails"."is_reminder", "emails"."clicked_at", "emails"."unsubscribed_at", "emails"."html", "emails"."eid", "emails"."sent_at", "emails"."sendgrid_x_message_id" FROM "emails" WHERE (LOWER("emails"."recipient_email") = \'micro.magic@woweee.io\') ORDER BY emails.created_at desc, "emails"."id" DESC LIMIT 20 OFFSET 0'
2025-01-13 22:47:43.243195 D ActiveRecord::Base --    (1.4ms)  EXPLAIN SELECT "emails"."id", "emails"."email_template_id", "emails"."created_at", "emails"."updated_at", "emails"."recipient_email", "emails"."customer_id", "emails"."variables", "emails"."is_test", "emails"."idempotency_key", "emails"."mandrill_message_id", "emails"."mandrill_message_status", "emails"."mandrill_message_reject_reason", "emails"."is_reminder", "emails"."clicked_at", "emails"."unsubscribed_at", "emails"."html", "emails"."eid", "emails"."sent_at", "emails"."sendgrid_x_message_id" FROM "emails" WHERE (LOWER("emails"."recipient_email") = 'micro.magic@woweee.io') ORDER BY emails.created_at desc, "emails"."id" DESC LIMIT 20 OFFSET 0
=>
[["Limit  (cost=0.14..8.16 rows=1 width=354)"],
 ["  ->  Index Scan using idx_emails_lower_rec_email_created_at_id on emails  (cost=0.14..8.16 rows=1 width=354)"],
 ["        Index Cond: (lower((recipient_email)::text) = 'micro.magic@woweee.io'::text)"]]
014 development johnnyclean >
```