### PR TITLE
Collection template uses `__` instead of `/` for namespaced models

### DIFF
--- a/app/views/administrate/application/_collection.html.erb
+++ b/app/views/administrate/application/_collection.html.erb
@@ -33,7 +33,7 @@ to display a collection of resources in an HTML table.
           collection_presenter.order_params_for(attr_name, key: collection_field_name)
         )) do %>
         <%= t(
-          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          "helpers.label.#{collection_presenter.resource_name.gsub("/", "__")}.#{attr_name}",
           default: resource_class.human_attribute_name(attr_name),
         ).titleize %>
             <% if collection_presenter.ordered_by?(attr_name) %>


### PR DESCRIPTION
Keeping this consistent with our webapp changes, per discussion here
https://github.com/rinsed-org/web/pull/14812#discussion_r1932244799