### PR TITLE
feat: add search_skip_cast to allow dynamic casting of specific fields

### DIFF
--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -22,6 +22,10 @@ module Administrate
 
       # RINSED: add support for exact matches only in search for query efficiency
       # eg. searching by email address in the (very large) emails table
+      def self.search_skip_cast?
+        false
+      end
+
       def self.search_exact?
         false
       end

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -31,6 +31,10 @@ module Administrate
 
       # RINSED: add support for exact matches only in search for query efficiency
       # eg. searching by email address in the (very large) emails table
+      def search_skip_cast?
+        options.fetch(:search_skip_cast, deferred_class.search_skip_cast?)
+      end
+
       def search_exact?
         options.fetch(:search_exact, deferred_class.search_exact?)
       end

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -88,7 +88,7 @@ module Administrate
           attribute_type = attribute_types[attr]
 
           search_target = "#{table_name}.#{column_name}"
-          search_target = "CAST(#{search_target} AS CHAR(256))" unless attribute_type.search_exact?
+          search_target = "CAST(#{search_target} AS CHAR(256))" unless attribute_type.search_skip_cast?
           search_target = "LOWER(#{search_target})" if attribute_type.search_lower?
 
           if attribute_type.search_exact?

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -17,7 +17,7 @@ describe CustomerDashboard do
 
       fields = dashboard.attribute_types
 
-      expect(fields[:name]).to eq(Field::String.with_options(search_exact: true))
+      expect(fields[:name]).to eq(Field::String.with_options(search_skip_cast: true, search_exact: true))
       expect(fields[:email]).to eq(Field::Email)
       expect(fields[:lifetime_value]).
         to eq(Field::Number.with_options(prefix: "$", decimals: 2))
@@ -33,7 +33,7 @@ describe CustomerDashboard do
       it "returns the attribute field" do
         dashboard = CustomerDashboard.new
         field = dashboard.attribute_type_for(:name)
-        expect(field).to eq Administrate::Field::String.with_options(search_exact: true)
+        expect(field).to eq Administrate::Field::String.with_options(search_skip_cast: true, search_exact: true)
       end
     end
 
@@ -52,7 +52,7 @@ describe CustomerDashboard do
         dashboard = CustomerDashboard.new
         fields = dashboard.attribute_types_for([:name, :email])
         expect(fields).to match(
-          name: Administrate::Field::String.with_options(search_exact: true),
+          name: Administrate::Field::String.with_options(search_skip_cast: true, search_exact: true),
           email: Administrate::Field::Email,
         )
       end

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -10,7 +10,7 @@ class CustomerDashboard < Administrate::BaseDashboard
 
     # RINSED: add support for exact matches only in search for query efficiency
     # eg. searching by email address in the (very large) emails table
-    name: Field::String.with_options(search_exact: true),
+    name: Field::String.with_options(search_skip_cast: true, search_exact: true),
 
     orders: Field::HasMany.with_options(limit: 2, sort_by: :id),
     log_entries: Field::HasManyVariant.with_options(limit: 2, sort_by: :id),


### PR DESCRIPTION
Gives more flexablity to search options on text fields, splits `search_lower` into two option, the second being `search_skip_cast` so that we don't have to wrap the query with: `"CAST(#{search_target} AS CHAR(256))"`
This is important when searching large fields of text, so as not to truncate it to the first 256 characters.

[sc-72066](https://app.shortcut.com/rinsed/story/72066/admin-supportagent-conversationscontroller-index?vc_group_by=day&ct_workflow=all&cf_workflow=500004189)