### PR TITLE
feat: add search_skip_cast to allow dynamic casting of specific fields

### DIFF
--- a/lib/administrate/field/base.rb
+++ b/lib/administrate/field/base.rb
@@ -22,6 +22,10 @@ module Administrate
 
       # RINSED: add support for exact matches only in search for query efficiency
       # eg. searching by email address in the (very large) emails table
+      def self.search_skip_cast?
+        false
+      end
+
       def self.search_exact?
         false
       end

--- a/lib/administrate/field/deferred.rb
+++ b/lib/administrate/field/deferred.rb
@@ -31,6 +31,10 @@ module Administrate
 
       # RINSED: add support for exact matches only in search for query efficiency
       # eg. searching by email address in the (very large) emails table
+      def search_skip_cast?
+        options.fetch(:search_skip_cast, deferred_class.search_skip_cast?)
+      end
+
       def search_exact?
         options.fetch(:search_exact, deferred_class.search_exact?)
       end

--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -95,7 +95,7 @@ module Administrate
           attribute_type = attribute_types[attr]
 
           search_target = "#{table_name}.#{column_name}"
-          search_target = "CAST(#{search_target} AS CHAR(256))" unless attribute_type.search_exact?
+          search_target = "CAST(#{search_target} AS CHAR(256))" unless attribute_type.search_skip_cast?
           search_target = "LOWER(#{search_target})" if attribute_type.search_lower?
 
           if attribute_type.search_exact?

--- a/spec/dashboards/customer_dashboard_spec.rb
+++ b/spec/dashboards/customer_dashboard_spec.rb
@@ -17,7 +17,7 @@ describe CustomerDashboard do
 
       fields = dashboard.attribute_types
 
-      expect(fields[:name]).to eq(Field::String.with_options(search_exact: true))
+      expect(fields[:name]).to eq(Field::String.with_options(search_skip_cast: true, search_exact: true))
       expect(fields[:email]).to eq(Field::Email)
       expect(fields[:lifetime_value]).
         to eq(Field::Number.with_options(prefix: "$", decimals: 2))
@@ -33,7 +33,7 @@ describe CustomerDashboard do
       it "returns the attribute field" do
         dashboard = CustomerDashboard.new
         field = dashboard.attribute_type_for(:name)
-        expect(field).to eq Administrate::Field::String.with_options(search_exact: true)
+        expect(field).to eq Administrate::Field::String.with_options(search_skip_cast: true, search_exact: true)
       end
     end
 
@@ -52,7 +52,7 @@ describe CustomerDashboard do
         dashboard = CustomerDashboard.new
         fields = dashboard.attribute_types_for([:name, :email])
         expect(fields).to match(
-          name: Administrate::Field::String.with_options(search_exact: true),
+          name: Administrate::Field::String.with_options(search_skip_cast: true, search_exact: true),
           email: Administrate::Field::Email,
         )
       end

--- a/spec/example_app/app/dashboards/customer_dashboard.rb
+++ b/spec/example_app/app/dashboards/customer_dashboard.rb
@@ -10,7 +10,7 @@ class CustomerDashboard < Administrate::BaseDashboard
 
     # RINSED: add support for exact matches only in search for query efficiency
     # eg. searching by email address in the (very large) emails table
-    name: Field::String.with_options(search_exact: true),
+    name: Field::String.with_options(search_skip_cast: true, search_exact: true),
 
     orders: Field::HasMany.with_options(limit: 2, sort_by: :id),
     log_entries: Field::HasManyVariant.with_options(limit: 2, sort_by: :id),

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -187,7 +187,7 @@ describe Administrate::Search do
       )
       expected_query = [
         [
-          'LOWER("users"."name") = ?',
+          'LOWER(CAST("users"."name" AS CHAR(256))) = ?',
           'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
         ].join(" OR "),
         "test",

--- a/spec/lib/administrate/search_spec.rb
+++ b/spec/lib/administrate/search_spec.rb
@@ -140,6 +140,99 @@ describe Administrate::Search do
       remove_constants :User
     end
 
+    it "skips CAST when search_skip_cast is true" do
+      class User < ApplicationRecord; end
+      class UserDashboardWithSkipCast < Administrate::BaseDashboard
+        ATTRIBUTE_TYPES = {
+          name: Administrate::Field::String.with_options(search_skip_cast: true),
+          email: Administrate::Field::Email,
+        }.freeze
+      end
+
+      scoped_object = User.default_scoped
+      search = Administrate::Search.new(
+        scoped_object,
+        UserDashboardWithSkipCast.new,
+        "test",
+      )
+      expected_query = [
+        [
+          'LOWER("users"."name") LIKE ?',
+          'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+        ].join(" OR "),
+        "%test%",
+        "%test%",
+      ]
+      expect(scoped_object).to receive(:where).with(*expected_query)
+
+      search.run
+    ensure
+      remove_constants :User, :UserDashboardWithSkipCast
+    end
+
+    it "uses exact match with = when search_exact is true" do
+      class User < ApplicationRecord; end
+      class UserDashboardWithExact < Administrate::BaseDashboard
+        ATTRIBUTE_TYPES = {
+          name: Administrate::Field::String.with_options(search_exact: true),
+          email: Administrate::Field::Email,
+        }.freeze
+      end
+
+      scoped_object = User.default_scoped
+      search = Administrate::Search.new(
+        scoped_object,
+        UserDashboardWithExact.new,
+        "test",
+      )
+      expected_query = [
+        [
+          'LOWER("users"."name") = ?',
+          'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+        ].join(" OR "),
+        "test",
+        "%test%",
+      ]
+      expect(scoped_object).to receive(:where).with(*expected_query)
+
+      search.run
+    ensure
+      remove_constants :User, :UserDashboardWithExact
+    end
+
+    it "combines search_skip_cast and search_exact options" do
+      class User < ApplicationRecord; end
+      class UserDashboardCombined < Administrate::BaseDashboard
+        ATTRIBUTE_TYPES = {
+          name: Administrate::Field::String.with_options(
+            search_skip_cast: true,
+            search_exact: true,
+          ),
+          email: Administrate::Field::Email,
+        }.freeze
+      end
+
+      scoped_object = User.default_scoped
+      search = Administrate::Search.new(
+        scoped_object,
+        UserDashboardCombined.new,
+        "test",
+      )
+      expected_query = [
+        [
+          'LOWER("users"."name") = ?',
+          'LOWER(CAST("users"."email" AS CHAR(256))) LIKE ?',
+        ].join(" OR "),
+        "test",
+        "%test%",
+      ]
+      expect(scoped_object).to receive(:where).with(*expected_query)
+
+      search.run
+    ensure
+      remove_constants :User, :UserDashboardCombined
+    end
+
     it "converts search term LOWER case for latin and cyrillic strings" do
       class User < ApplicationRecord; end
       scoped_object = User.default_scoped

--- a/spec/lib/fields/deferred_spec.rb
+++ b/spec/lib/fields/deferred_spec.rb
@@ -98,6 +98,70 @@ describe Administrate::Field::Deferred do
     end
   end
 
+  describe "#search_skip_cast?" do
+    context "when given a `search_skip_cast` option" do
+      it "returns the value given" do
+        skip_cast_deferred = Administrate::Field::Deferred.new(
+          double(search_skip_cast?: false),
+          search_skip_cast: true,
+        )
+        cast_deferred = Administrate::Field::Deferred.new(
+          double(search_skip_cast?: true),
+          search_skip_cast: false,
+        )
+
+        expect(skip_cast_deferred.search_skip_cast?).to eq(true)
+        expect(cast_deferred.search_skip_cast?).to eq(false)
+      end
+    end
+
+    context "when not given a `search_skip_cast` option" do
+      it "falls back to the default of the deferred class" do
+        skip_cast_deferred = Administrate::Field::Deferred.new(
+          double(search_skip_cast?: true),
+        )
+        cast_deferred = Administrate::Field::Deferred.new(
+          double(search_skip_cast?: false),
+        )
+
+        expect(skip_cast_deferred.search_skip_cast?).to eq(true)
+        expect(cast_deferred.search_skip_cast?).to eq(false)
+      end
+    end
+  end
+
+  describe "#search_exact?" do
+    context "when given a `search_exact` option" do
+      it "returns the value given" do
+        exact_deferred = Administrate::Field::Deferred.new(
+          double(search_exact?: false),
+          search_exact: true,
+        )
+        fuzzy_deferred = Administrate::Field::Deferred.new(
+          double(search_exact?: true),
+          search_exact: false,
+        )
+
+        expect(exact_deferred.search_exact?).to eq(true)
+        expect(fuzzy_deferred.search_exact?).to eq(false)
+      end
+    end
+
+    context "when not given a `search_exact` option" do
+      it "falls back to the default of the deferred class" do
+        exact_deferred = Administrate::Field::Deferred.new(
+          double(search_exact?: true),
+        )
+        fuzzy_deferred = Administrate::Field::Deferred.new(
+          double(search_exact?: false),
+        )
+
+        expect(exact_deferred.search_exact?).to eq(true)
+        expect(fuzzy_deferred.search_exact?).to eq(false)
+      end
+    end
+  end
+
   describe "#==" do
     it "returns false for different deferred classes" do
       one = Administrate::Field::Deferred.new(String)


### PR DESCRIPTION
Gives more flexablity to search options on text fields, splits search_lower into two option, the second being search_skip_cast so that we don't have to wrap the query with: "CAST(#{search_target} AS CHAR(256))"
This is important when searching large fields of text, so as not to truncate it to the first 256 characters.

[sc-72066](https://app.shortcut.com/rinsed/story/72066/admin-supportagent-conversationscontroller-index?vc_group_by=day&ct_workflow=all&cf_workflow=500004189)