### PR TITLE
Replace String#mb_chars with plain string methods

### DIFF
--- a/lib/administrate/search.rb
+++ b/lib/administrate/search.rb
@@ -120,9 +120,9 @@ module Administrate
         attribute_type = attribute_types[attr]
 
         search_term = if attribute_type.search_lower?
-          term.mb_chars.downcase
+          term.downcase
         else
-          term.mb_chars
+          term
         end
 
         if attribute_type.search_exact?


### PR DESCRIPTION
Rails 8.1 deprecates `String#mb_chars` (removal in 8.2). Apps configured to raise on deprecations —
like `web` in the test environment — get a 500 on **any** Administrate search with a term, since
`Administrate::Search#query_values` calls it on every search.

## Why this is safe to just drop

`.mb_chars` was added upstream in [9dc81e5e](https://github.com/thoughtbot/administrate/commit/9dc81e5e)
("Add support for cyrillic search", May 2017), which changed `term.downcase` to `term.mb_chars.downcase`.
At the time that fixed a real bug: Ruby < 2.4's `String#downcase` was ASCII-only, so `"Тест"` came back
unchanged and Cyrillic searches found nothing.

Two things have since made it a no-op:

1. Ruby 2.4 (Dec 2016) made `String#downcase` fully Unicode-aware.
2. `ActiveSupport::Multibyte::Chars` no longer implements `downcase` at all. In Active Support 8.1 it has
   no such method — `method_missing` forwards straight to the wrapped String:

   ```ruby
   # active_support/multibyte/chars.rb:72
   def method_missing(method, ...)
     result = @wrapped_string.__send__(method, ...)   # ← String#downcase
     ...
   end
   ```

So `term.mb_chars.downcase` is already `term.downcase`, just with a wrapper allocated around the result.
That is exactly what the deprecation means by "Use normal string methods instead."

Verified identical output for `s.downcase` vs `s.mb_chars.downcase.to_s` on Ruby 4.0.6 across Cyrillic,
Latin accents, Greek final sigma, German sharp s, Turkish dotted İ, Croatian digraphs, and mixed
ASCII/emoji — no mismatches.

## Coverage

The original regression spec still guards this: "converts search term LOWER case for latin and cyrillic
strings" in `spec/lib/administrate/search_spec.rb`, which asserts `"Тест Test"` produces `"%тест test%"`.

Note: this repo's bundle can't currently install (`Gemfile.lock` pins the yanked `i18n-tasks 0.9.37` and
bundler 2.3.5), so that suite was not run here. The change was verified end-to-end from the `web` app
instead.

## Downstream

`web` pins this fork by ref, so it needs a `Gemfile`/`Gemfile.lock` bump to the merge commit once this
lands. Tracking in rinsed-org/web#24775 (Rails 8.0.5.1 → 8.1.3.1).
