### PR TITLE
Add Arby PR review bot workflows

### DIFF
--- a/.github/workflows/review-manual-request.yml
+++ b/.github/workflows/review-manual-request.yml
@@ -1,0 +1,48 @@
+# Ask Arby (rinsed-review-bot) for a review on demand: pick it in the Reviewers gear, or press the 🔄
+# re-request button next to it. Works on drafts too, which review.yml skips. Same setup as review.yml —
+# runs on the base branch (pull_request_target); keep both files' `with:` inputs in sync.
+#
+# `review_requested` fires for every reviewer request — humans, and any team a ruleset auto-requests — so
+# PRs can show one skipped run here; only requests aimed at Arby itself run. This check is not required
+# (that's review.yml's "Arby Review"); if a run breaks, re-run it from the Actions tab.
+name: Review (manual request)
+
+on:
+  pull_request_target:
+    types: [review_requested]
+
+# Read-only token: the workflow only reads the PR as data. The only credential that can write is Arby's own
+# PAT (org secret RINSED_REVIEW_BOT_TOKEN), and the action uses it solely to post the review.
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  review:
+    name: Arby Review (manual request)
+    # Team requests (like a ruleset's auto-request) have no requested_reviewer, so they skip here too.
+    if: github.event.requested_reviewer.login == 'rinsed-review-bot'
+    # Shares review.yml's group so a manual review and an automatic one never run at once. No cancelling
+    # here: cancelling an in-flight automatic run would kill the required "Arby Review" check without
+    # replacing it (this job reports under a different name), so a manual run queues instead. Job-level so
+    # skipped runs stay out of the group.
+    concurrency:
+      group: arby-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Arby review
+        uses: rinsed-org/review-bot-workflows@v2
+        with:
+          # Org-level secrets, available to every rinsed-org repo. (Passed explicitly because a composite
+          # action can't read secrets on its own.)
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          review-bot-token: ${{ secrets.RINSED_REVIEW_BOT_TOKEN }}
+
+          # This is a public fork of thoughtbot/administrate, so anyone can open a PR here. Only our
+          # developers get a real verdict (approve / request changes); everyone else gets a comment only.
+          limit-approval-to: rinsed-org/development
+
+          # Only P0/P1 findings block approval (also the shared default, set explicitly for clarity).
+          blocking-severities: P0,P1

--- a/.github/workflows/review-manual-request.yml
+++ b/.github/workflows/review-manual-request.yml
@@ -1,10 +1,19 @@
-# Ask Arby (rinsed-review-bot) for a review on demand: pick it in the Reviewers gear, or press the 🔄
-# re-request button next to it. Works on drafts too, which review.yml skips. Same setup as review.yml —
-# runs on the base branch (pull_request_target); keep both files' `with:` inputs in sync.
+# Ask Arby (rinsed-review-bot) for a review on demand. Works on drafts too, which review.yml skips. Same
+# setup as review.yml — runs on the base branch (pull_request_target); keep both files' `with:` inputs in
+# sync.
 #
-# `review_requested` fires for every reviewer request — humans, and any team a ruleset auto-requests — so
-# PRs can show one skipped run here; only requests aimed at Arby itself run. This check is not required
-# (that's review.yml's "Arby Review"); if a run breaks, re-run it from the Actions tab.
+# To ask for one: press the 🔄 re-request button next to `rinsed-review-bot` in the PR's Reviewers sidebar.
+# Arby lands in that sidebar by reviewing, so for a re-review the button is always already there; if Arby
+# has never reviewed the PR (a draft, which review.yml skips), pick it from the sidebar's gear instead.
+# Either way it must be Arby the *user* — requesting a team, even @rinsed-org/dev-and-review-bot, does not
+# trigger a review. A request that lands always creates a NEW run of this workflow, so if no new run
+# appears, it never reached Arby.
+#
+# Skipped runs here are normal: `review_requested` fires for every reviewer request, so a ruleset that
+# auto-requests teams when a PR opens leaves one skipped run per team. Only requests aimed at Arby itself
+# run. Re-running a skipped run does nothing — a re-run replays the original event, which still names a
+# team, so it skips again every time. Push a commit or re-request Arby instead. This check is not required
+# (that's review.yml's "Arby Review").
 name: Review (manual request)
 
 on:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,49 @@
+# Arby (rinsed-review-bot), our PR review bot. The review logic lives in the shared
+# rinsed-org/review-bot-workflows action; this repo's CODE_REVIEW.md / CLAUDE.md customize what it flags.
+# Runs on the base branch (pull_request_target), so a PR can't edit the workflow that reviews it.
+#
+# Asking Arby directly for a review is handled by review-manual-request.yml — keep both files'
+# `with:` inputs in sync.
+name: Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+# Read-only token: the workflow only reads the PR as data. The only credential that can write is Arby's own
+# PAT (org secret RINSED_REVIEW_BOT_TOKEN), and the action uses it solely to post the review.
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+
+jobs:
+  review:
+    # The required check is keyed on this name. Only this workflow produces it, so no skipped run elsewhere
+    # can stand in for a real review.
+    name: Arby Review
+    # Drafts skip — to review a draft anyway, request a review from Arby (review-manual-request.yml).
+    # Dependabot PRs run but do nothing (Dependabot's token can't read the secrets); the check still goes
+    # green.
+    if: github.event.pull_request.draft == false
+    # One review per PR at a time, shared with review-manual-request.yml: the newest run cancels older
+    # in-flight ones. Job-level so skipped runs stay out of the group.
+    concurrency:
+      group: arby-review-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Arby review
+        uses: rinsed-org/review-bot-workflows@v2
+        with:
+          # Org-level secrets, available to every rinsed-org repo. (Passed explicitly because a composite
+          # action can't read secrets on its own.)
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          review-bot-token: ${{ secrets.RINSED_REVIEW_BOT_TOKEN }}
+
+          # This is a public fork of thoughtbot/administrate, so anyone can open a PR here. Only our
+          # developers get a real verdict (approve / request changes); everyone else gets a comment only.
+          limit-approval-to: rinsed-org/development
+
+          # Only P0/P1 findings block approval (also the shared default, set explicitly for clarity).
+          blocking-severities: P0,P1

--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,100 @@
+# Code review notes
+
+Per-repo guidance for reviewers (human and Arby). The shared rubric — what counts as a finding, the P0–P3
+severities — lives in [rinsed-org/review-bot-workflows](https://github.com/rinsed-org/review-bot-workflows);
+this file adds only what is specific to this repo.
+
+## What this repo is
+
+A **fork of [thoughtbot/administrate](https://github.com/thoughtbot/administrate)**, not a standalone
+project. The `rinsed-v0.17.0` branch is upstream's `v0.17.0` tag plus our patches, and it is what the Rinsed
+app's `Gemfile` points at. Two consequences drive most of the review:
+
+- **Divergence is a liability.** Every line we change is a line to re-apply when we rebase onto a newer
+  upstream release. The diff against `v0.17.0` is currently ~50 files; keeping it small and legible is a
+  goal in itself.
+- **This is a published API.** The Rinsed app calls into these classes and overrides these views. Changing
+  or removing something the app might use is a breaking change made in a different repo than the one that
+  breaks.
+
+## Fork discipline
+
+- **Mark every divergence in an upstream-owned file.** Wrap it in `# RINSED: <why>` … `# END RINSED`
+  comments so the next rebase can find it. A change to an upstream file with no marker is a finding.
+  (Existing markers are inconsistent — both `# RINSED END` and `# END RINSED` appear, and some blocks have
+  no closer. Prefer `# END RINSED` for new code; don't churn the old ones.)
+- **Prefer additive over rewritten.** New behavior should be a new method with an upstream-compatible
+  default rather than an edit to upstream logic. `Field::Base.search_exact?` (default `false`) and
+  `search_lower?` (default `true`) are the model: dashboards that don't opt in behave exactly as upstream.
+  A change that alters default behavior for existing dashboards without an explicit opt-in is a finding —
+  it will silently change the admin UI for every resource in the app.
+- **New specs go in `spec/rinsed/`**, mirroring the upstream path (e.g.
+  `spec/rinsed/lib/administrate/order_spec.rb`). Editing upstream spec files creates rebase conflicts;
+  only do it when the upstream expectation itself is now wrong, and mark it.
+- Comments like `# TODO: Upstream this` are meaningful here — flag Rinsed-only behavior that looks
+  generally useful and could go upstream instead of living in the fork forever.
+
+## Raw SQL: `lib/administrate/search.rb` and `lib/administrate/order.rb`
+
+These two files build **SQL by string interpolation** and hand it to `Arel.sql`, which explicitly tells
+Rails "trust me, this is safe." They are the highest-risk code in the repo and both carry Rinsed patches.
+On any diff touching them, check:
+
+- **The search term stays a bound parameter.** It is passed as `?` with values supplied separately
+  (`query_values`). A term reaching the SQL string itself — even via `sanitize`, even "just for a cast" —
+  is a **P0**.
+- **Interpolated identifiers stay behind their guards.** `Order#attribute` and `#direction` come straight
+  from `params`; the interpolated string is only safe because `sanitize_direction` allowlists
+  `asc`/`desc`, and because the query is executed only when `attribute` matches `relation.columns_hash` or
+  a real `reflect_on_association`. In `Search`, identifiers come from dashboard-declared attributes. A new
+  interpolation that isn't behind one of those guards, or a change that lets the built SQL execute without
+  the `columns_hash` check, is a **P0**.
+- **`search_skip_cast` changes the SQL shape.** Skipping the `CAST(... AS CHAR(256))` means the column's
+  real type reaches the comparison, so a non-text column can now raise or coerce differently, and
+  `search_lower?` interacts with it. Changes here want a spec covering the skip-cast × exact × lower
+  combinations, which `spec/lib/administrate/search_spec.rb` already exercises.
+- **Search runs against production-sized tables.** The whole point of `search_exact` was letting an indexed
+  column be searched without a `LIKE '%…%'` full scan. Flag changes that reintroduce a leading-wildcard or
+  a cast on a column that was deliberately exempted.
+
+## Public surface the Rinsed app depends on
+
+Treat these as API. Removing one, narrowing its visibility, or changing its signature breaks the app at
+runtime with nothing in this repo's CI to catch it:
+
+- `Administrate::Field::Base` / `Field::Deferred` class methods, including the Rinsed
+  `search_skip_cast?` / `search_exact?` / `search_lower?` trio and their `options.fetch` keys — those keys
+  are typed by hand in the app's dashboards.
+- `Administrate::Page::Form#dashboard` (public here, private upstream) and `#attributes_for`.
+- `Administrate::Page::Collection`'s `collection_attributes:` option.
+- `Administrate::Field::HasMany#collection_partial` and `#associated_collection`.
+- `Administrate::Punditize` — it depends on Pundit internals (`Pundit::Authorization`,
+  `Pundit::PolicyFinder`, the `@_pundit_policy_scoped` ivar) that Pundit can rename in a minor release.
+- **View partials and their locals.** Host apps override partials by path, so renaming one or changing the
+  locals passed to it (e.g. `_collection.html.erb`, `fields/has_many/_show.html.erb`) breaks overrides in
+  the app silently. Flag changes to partial names, local names, and the i18n keys built in them — including
+  the `resource_name.gsub("/", "__")` namespacing, which the app's locale files are keyed to.
+
+## What CI does and does not cover
+
+CI (`.github/workflows/main.yml`) runs exactly one job: **Ruby 3.1, the root `Gemfile`, Postgres 14,
+`bundle exec rspec`**. So don't duplicate "this spec fails" — but *do* flag what CI cannot see:
+
+- **The Rails version matrix is not run.** `Appraisals` declares `rails60`, `rails61`, and `rails70`, and
+  `gemfiles/` has locks for each, but no CI job uses them. Code relying on an API added in a newer Rails —
+  or removed in an older one — will pass CI and break a consumer. Call it out.
+- **No linter.** There is no RuboCop config and no lint step; style regressions are on review.
+- **`bundler:audit` is not run by CI.** It is wired into `rake default`, which CI does not invoke.
+- **JS is untested.** `app/assets/javascripts/` has no test coverage at all, and we've already diverged
+  there: `jquery_ujs` is removed from the asset manifest (three feature specs are skipped as a result, with
+  `RINSED:` notes) and selectize is applied to `.field-unit select` broadly rather than per field type.
+  Changes to those files are reviewed by reading only — be correspondingly careful, and check whether a
+  selector change catches inputs it shouldn't.
+
+## Not worth flagging
+
+- Upstream code style we inherited. This is thoughtbot's codebase; a finding whose only substance is
+  "upstream would write this differently" is noise.
+- `CHANGELOG.md` entries. It tracks upstream releases, not our patches.
+- Missing translations in the non-English `config/locales/administrate.*.yml` files — we don't maintain
+  them. A **new** user-facing string still needs an `administrate.en.yml` entry.


### PR DESCRIPTION
Adopts the shared [rinsed-org/review-bot-workflows](https://github.com/rinsed-org/review-bot-workflows) composite action (pinned to `@v2`) so Arby reviews PRs on this repo.

### Workflows

- **`.github/workflows/review.yml`** — reviews every non-draft PR on open / synchronize / reopen / ready-for-review. Produces the `Arby Review` check.
- **`.github/workflows/review-manual-request.yml`** — reviews on demand when Arby is requested as a reviewer, including on drafts.

Both run on `pull_request_target` with a read-only `GITHUB_TOKEN`, so a PR can't edit the workflow that reviews it; the action never checks out or runs PR code.

Inputs:

- `limit-approval-to: rinsed-org/development` — this is a public fork of thoughtbot/administrate, so anyone can open a PR. Only our developers' PRs get a binding verdict (approve / request changes); everyone else gets a non-binding comment.
- `blocking-severities: P0,P1` — the shared default, set explicitly.

### `CODE_REVIEW.md`

Arby reads this from the base branch on every run; it's where per-repo review concerns go. It covers what the shared rubric can't know about this repo:

- **Fork discipline** — mark divergence from upstream with `# RINSED:` / `# END RINSED`, prefer additive changes with upstream-compatible defaults, and put new specs in `spec/rinsed/` so rebases onto a newer upstream stay tractable.
- **The raw SQL in `Administrate::Search` and `Administrate::Order`** — interpolated identifiers are safe only behind `sanitize_direction`'s allowlist and the `columns_hash` check, and the search term must stay a bound parameter. Both files carry our patches, so they're the ones most likely to change.
- **The public surface the Rinsed app depends on** — including view partial names, their locals, and the i18n key namespacing — since breaking it fails in a different repo than the one that changed.
- **What CI does not cover** — the Appraisal Rails matrix (lockfiles exist, no job runs them), linting, `bundler:audit`, and all JavaScript.
- **What isn't worth flagging** — inherited upstream style, `CHANGELOG.md`, and the unmaintained non-English locales.

### Base branch

Branched off and targeting `rinsed-v0.17.0` (the branch our app uses) rather than the repo default `rinsed-v1`. `pull_request_target` workflows run from the PR's *base* branch, so these files need to live on `rinsed-v0.17.0` for PRs against it to get reviewed — which also means Arby won't review this PR itself; it starts on the next one.

### Remaining setup (outside this PR)

- Secrets: `RINSED_REVIEW_BOT_TOKEN` and `OPENAI_API_KEY` are already org-level — nothing to add.
- Add the [`@rinsed-org/dev-and-review-bot`](https://github.com/orgs/rinsed-org/teams/dev-and-review-bot) team to this repo with **write** access so the bot's review counts.